### PR TITLE
feat:Inline graph editing with bidirectional updates between the graph and the schema

### DIFF
--- a/src/components/CustomReactFlowNode.tsx
+++ b/src/components/CustomReactFlowNode.tsx
@@ -12,7 +12,7 @@ const CustomNode = ({
   id: string;
   selected: boolean;
 }) => {
-  const { theme } = useContext(AppContext);
+  const { theme, updateSchemaAtPath } = useContext(AppContext);
 
   const rowRefs = useRef<
     Record<string, HTMLDivElement | HTMLSpanElement | null>
@@ -20,6 +20,14 @@ const CustomNode = ({
   const [handleOffsets, setHandleOffsets] = useState<Record<string, number>>(
     {}
   );
+
+  const [editingField, setEditingField] = useState<{
+    type: "key" | "value";
+    rowKey: string;
+    item?: string;
+    index?: number;
+  } | null>(null);
+  const [editValue, setEditValue] = useState("");
 
   const updateNodeInternals = useUpdateNodeInternals();
   useEffect(() => {
@@ -36,6 +44,60 @@ const CustomNode = ({
 
     setHandleOffsets(offsets);
   }, [data.nodeData]);
+
+  const getPathFromNodeId = (nodeId: string): (string | number)[] => {
+    const uriParts = nodeId.split("#");
+    const fragment = uriParts.length > 1 ? uriParts[1] : "";
+    return fragment
+      .split("/")
+      .filter((segment) => segment !== "")
+      .map((segment) => {
+        const decoded = decodeURIComponent(segment);
+        return /^\d+$/.test(decoded) ? parseInt(decoded, 10) : decoded;
+      });
+  };
+
+  const parseInputValue = (val: string) => {
+    if (val === "true") return true;
+    if (val === "false") return false;
+    if (val === "null") return null;
+    if (!isNaN(Number(val)) && val.trim() !== "") return Number(val);
+    if (val.startsWith('"') && val.endsWith('"')) {
+      return val.slice(1, -1);
+    }
+    return val;
+  };
+
+  const handleStartEdit = (type: "key" | "value", rowKey: string, currentVal: string, item?: string, index?: number) => {
+    setEditingField({ type, rowKey, item, index });
+    setEditValue(currentVal);
+  };
+
+  const handleSaveEdit = () => {
+    if (!editingField) return;
+    const basePath = getPathFromNodeId(id);
+    const parsedVal = parseInputValue(editValue);
+
+    if (editingField.rowKey === "properties" && editingField.item) {
+      const fullPath = [...basePath, "properties", editingField.item];
+      updateSchemaAtPath(fullPath, parsedVal, true);
+    } else if (editingField.rowKey === "required" && editingField.index !== undefined) {
+      const fullPath = [...basePath, "required", editingField.index];
+      updateSchemaAtPath(fullPath, parsedVal, false);
+    } else {
+      const fullPath = [...basePath, editingField.rowKey];
+      updateSchemaAtPath(fullPath, parsedVal, false);
+    }
+    setEditingField(null);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleSaveEdit();
+    } else if (e.key === "Escape") {
+      setEditingField(null);
+    }
+  };
 
   const { color } = data.nodeStyle;
 
@@ -87,7 +149,11 @@ const CustomNode = ({
         {data.nodeLabel}
       </div>
 
-      <div className="flex flex-col">
+      <div 
+        className="flex flex-col animate-fadeIn"
+        onClick={(e) => e.stopPropagation()}
+        onDoubleClick={(e) => e.stopPropagation()}
+      >
         {Object.entries(data.nodeData).map(([key, keyData]) => {
           const isTypeColorMap =
             key === "type" &&
@@ -99,7 +165,7 @@ const CustomNode = ({
           return (
             <div
               key={key}
-              className={`${data.isBooleanNode && "text-center"} flex`}
+              className={`${data.isBooleanNode && "text-center"} flex items-center justify-between`}
               style={{
                 border: `1px solid ${data.nodeStyle.color}40`,
                 padding: "4px",
@@ -138,27 +204,72 @@ const CustomNode = ({
                 </div>
               ) : isArray ? (
                 <div className="flex-col w-full gap-1 flex py-1">
-                  {(keyData.value as string[]).map((item, index) => (
-                    <div
-                      ref={(el) => {
-                        rowRefs.current[`${id}-${item}`] = el;
-                      }}
-                      key={index}
-                      className="px-2 py-[2px] bg-[var(--node-value-bg-color)]"
-                      style={{ border: `1px solid ${color}30` }}
-                    >
-                      {item}
-                    </div>
-                  ))}
+                   {(keyData.value as string[]).map((item, index) => {
+                    const isEditableArray = key === "properties" || key === "required";
+                    const isEditingThis =
+                      isEditableArray &&
+                      editingField?.rowKey === key &&
+                      editingField?.index === index;
+
+                    return isEditingThis ? (
+                      <input
+                        key={index}
+                        value={editValue}
+                        onChange={(e) => setEditValue(e.target.value)}
+                        onBlur={handleSaveEdit}
+                        onKeyDown={handleKeyDown}
+                        className="px-1 py-[2px] text-xs bg-[var(--node-value-bg-color)] border border-blue-500 rounded text-foreground w-full focus:outline-none"
+                        autoFocus
+                      />
+                    ) : (
+                      <div
+                        ref={(el) => {
+                          rowRefs.current[`${id}-${item}`] = el;
+                        }}
+                        key={index}
+                        onDoubleClick={() => {
+                          if (isEditableArray) {
+                            handleStartEdit(key === "properties" ? "key" : "value", key, item, item, index);
+                          }
+                        }}
+                        className={`px-2 py-[2px] bg-[var(--node-value-bg-color)] ${isEditableArray ? "cursor-text select-text" : ""}`}
+                        style={{ border: `1px solid ${color}30` }}
+                        title={isEditableArray ? "Double click to edit" : undefined}
+                      >
+                        {item}
+                      </div>
+                    );
+                  })}
                 </div>
               ) : (
-                <span
-                  ref={(el) => {
-                    rowRefs.current[`${id}-${key}`] = el;
-                  }}
-                >
-                  {keyData.ellipsis ?? String(keyData.value)}
-                </span>
+                (() => {
+                  const isEditingThis =
+                    editingField?.rowKey === key &&
+                    editingField?.type === "value";
+                  const currentStr = String(keyData.value);
+
+                  return isEditingThis ? (
+                    <input
+                      value={editValue}
+                      onChange={(e) => setEditValue(e.target.value)}
+                      onBlur={handleSaveEdit}
+                      onKeyDown={handleKeyDown}
+                      className="px-1 py-[2px] text-xs bg-[var(--node-value-bg-color)] border border-blue-500 rounded text-foreground w-full focus:outline-none"
+                      autoFocus
+                    />
+                  ) : (
+                    <span
+                      ref={(el) => {
+                        rowRefs.current[`${id}-${key}`] = el;
+                      }}
+                      onDoubleClick={() => handleStartEdit("value", key, currentStr)}
+                      className="cursor-text select-text"
+                      title="Double click to edit value"
+                    >
+                      {keyData.ellipsis ?? currentStr}
+                    </span>
+                  );
+                })()
               )}
             </div>
           );

--- a/src/contexts/AppContext.tsx
+++ b/src/contexts/AppContext.tsx
@@ -9,6 +9,8 @@ export type SelectedNode = {
 
 export type NavigationDirection = "next" | "prev";
 
+export type LayoutOrientation = "TB" | "LR";
+
 type AppContextType = {
   containerRef: Ref<HTMLDivElement>;
   isFullScreen: boolean;
@@ -34,6 +36,15 @@ type AppContextType = {
 
   registerExportGraph: (fn: () => void) => void;
   triggerExportGraph: () => void;
+
+  layoutOrientation: LayoutOrientation;
+  setLayoutOrientation: (orientation: LayoutOrientation) => void;
+
+  updateSchemaAtPath: (
+    path: (string | number)[],
+    newValue: any,
+    isKeyChange: boolean
+  ) => void;
 };
 
 export const AppContext = createContext<AppContextType>({} as AppContextType);

--- a/src/contexts/AppProvider.tsx
+++ b/src/contexts/AppProvider.tsx
@@ -10,10 +10,13 @@ import {
   type NavigationDirection,
   type SchemaFormat,
   type SelectedNode,
+  type LayoutOrientation,
 } from "./AppContext";
 
 import defaultSchema from "../data/defaultJSONSchema.json";
 import YAML from "js-yaml";
+import { modify, applyEdits, parseTree, findNodeAtLocation } from "jsonc-parser";
+import { parseDocument } from "yaml";
 
 import { SESSION_SCHEMA_KEY, SESSION_FORMAT_KEY } from "../constants";
 
@@ -81,6 +84,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
 
   const [selectedNode, setSelectedNode] = useState<SelectedNode | null>(null);
   const [searchString, setSearchString] = useState("");
+  const [layoutOrientation, setLayoutOrientation] = useState<LayoutOrientation>("LR");
 
   const navigateMatchRef = useRef<((dir: NavigationDirection) => void) | null>(
     null
@@ -148,6 +152,69 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     document.documentElement.setAttribute("data-theme", theme);
   }, [theme]);
 
+  const updateSchemaAtPath = useCallback(
+    (
+      path: (string | number)[],
+      newValue: any,
+      isKeyChange: boolean
+    ) => {
+      try {
+        let updatedText = schemaText;
+        if (schemaFormat === "yaml") {
+          const doc = parseDocument(schemaText);
+          if (isKeyChange) {
+            const parentPath = path.slice(0, -1);
+            const oldKey = path[path.length - 1];
+            const parentMap = doc.getIn(parentPath) as any;
+            if (parentMap && typeof parentMap.set === "function") {
+              const value = parentMap.get(oldKey);
+              parentMap.delete(oldKey);
+              parentMap.set(newValue, value);
+              updatedText = doc.toString();
+            }
+          } else {
+            doc.setIn(path, newValue);
+            updatedText = doc.toString();
+          }
+        } else {
+          // JSON format
+          if (isKeyChange) {
+            const tree = parseTree(schemaText);
+            if (tree) {
+              const parentPath = path.slice(0, -1);
+              const parentNode = findNodeAtLocation(tree, parentPath);
+              if (parentNode && parentNode.type === "object" && parentNode.children) {
+                const oldKey = path[path.length - 1];
+                const propNode = parentNode.children.find(
+                  (child) => child.children && child.children[0].value === oldKey
+                );
+                if (propNode && propNode.children) {
+                  const keyNode = propNode.children[0];
+                  const start = keyNode.offset;
+                  const end = keyNode.offset + keyNode.length;
+                  const newKeyStr = JSON.stringify(newValue);
+                  updatedText = schemaText.slice(0, start) + newKeyStr + schemaText.slice(end);
+                }
+              }
+            }
+          } else {
+            const edits = modify(schemaText, path, newValue, {
+              formattingOptions: {
+                insertSpaces: true,
+                tabSize: 2,
+              },
+            });
+            updatedText = applyEdits(schemaText, edits);
+          }
+        }
+        setSchemaText(updatedText);
+      } catch (err) {
+        console.error("Failed to update schema at path:", path, err);
+      }
+    },
+    [schemaText, schemaFormat]
+  );
+
   const value = {
     containerRef,
     isFullScreen,
@@ -166,6 +233,9 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
     triggerNavigateMatch,
     registerExportGraph,
     triggerExportGraph,
+    layoutOrientation,
+    setLayoutOrientation,
+    updateSchemaAtPath,
   };
 
   return <AppContext.Provider value={value}>{children}</AppContext.Provider>;


### PR DESCRIPTION
## Summary

This PR adds bidirectional synchronization between the graph visualization and the schema editor 

## Changes
-Added bidirectional synchronization between graph and schema.
-Changes made in the graph are reflected in the schema.
-Changes made in the schema are reflected in the graph
-Improved synchronization logic and state management. 



## Screenshots/Video


https://github.com/user-attachments/assets/d944152a-b730-4d20-b7e7-05bf9ac6c6d7



## Does this PR introduce a breaking change?

No, This will not introduce any break point 

Hello @AgniveshChaubey sir, I've implemented bidirectional synchronization between the graph and schema editor.
Could you please review this PR when you have time? I'd really appreciate your feedback. Thankyou!