### PR TITLE
Fix details popup: multi-type rendering and missing data after search…

### DIFF
--- a/.changeset/huge-cats-mate.md
+++ b/.changeset/huge-cats-mate.md
@@ -1,0 +1,5 @@
+---
+"json-schema-studio": patch
+---
+
+Fix details popup showing [object Object] for multi-type schemas and empty data after search navigation

--- a/src/components/GraphView.tsx
+++ b/src/components/GraphView.tsx
@@ -85,6 +85,7 @@ const GraphView = ({
 
         setSelectedNode({
           id: foundNode.id,
+          data: foundNode.data,
         });
         setCenter(x, y, { zoom: Math.max(getZoom(), 1), duration: 500 });
 
@@ -355,6 +356,7 @@ const GraphView = ({
 
         setSelectedNode({
           id: firstNode.id,
+          data: firstNode.data,
         });
 
         setCenter(x, y, { zoom: Math.max(getZoom(), 1), duration: 500 });

--- a/src/components/NodeDetailsPopup.tsx
+++ b/src/components/NodeDetailsPopup.tsx
@@ -29,7 +29,10 @@ const NodeDetailsPopup = ({
     }
   };
 
-  const formatValue = (value: string | string[]) => {
+  const formatValue = (value: unknown) => {
+    if (value && typeof value === "object" && !Array.isArray(value)) {
+      return <div>{Object.keys(value).join(" | ")}</div>;
+    }
     return (
       <div className="flex flex-col">
         {Array.isArray(value) ? (


### PR DESCRIPTION
## Summary

Fixes two bugs in the node details popup:
1. Multi-type schema fields (e.g. `"type": ["string", "null"]`) rendered as `[object Object]` instead of showing the actual types.
2. The popup showed no data when a node was selected via search navigation (arrows/auto-select), while direct clicks worked fine.

## What kind of change does this PR introduce

bug fix

## Screenshots/Video

BEFORE:-

https://github.com/user-attachments/assets/2d1d176c-378e-4529-8c77-bcacedefa9b4

AFTER:-

https://github.com/user-attachments/assets/6efd9914-278f-42a3-b1f5-c411d0a8cf09

## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

No, internal bug fix, no public API or user-facing docs affected.
