### PR TITLE
fix: prevent boolean node connection handle from clipping (fixes #394)

### DIFF
--- a/src/components/CustomReactFlowNode.tsx
+++ b/src/components/CustomReactFlowNode.tsx
@@ -44,7 +44,7 @@ const CustomNode = ({
       className={`
         ${
           data.isBooleanNode
-            ? "rounded-2xl text-center overflow-hidden"
+            ? "rounded-2xl text-center"
             : "rounded"
         }
         relative transition-shadow duration-300 text-sm bg-[var(--node-bg-color)] text-[var(--text-color)]
@@ -73,96 +73,98 @@ const CustomNode = ({
         />
       ))}
 
-      <div
-        className="px-2 font-semibold"
-        style={{
-          background: `${color}50`,
-          borderBottom: `1px solid ${color}`,
-          color:
-            theme === "dark"
-              ? color
-              : `color-mix(in srgb, ${color} 60%, black)`,
-        }}
-      >
-        {data.nodeLabel}
-      </div>
+      <div className="overflow-hidden rounded-[inherit]">
+        <div
+          className="px-2 font-semibold"
+          style={{
+            background: `${color}50`,
+            borderBottom: `1px solid ${color}`,
+            color:
+              theme === "dark"
+                ? color
+                : `color-mix(in srgb, ${color} 60%, black)`,
+          }}
+        >
+          {data.nodeLabel}
+        </div>
 
-      <div className="flex flex-col">
-        {Object.entries(data.nodeData).map(([key, keyData]) => {
-          const isTypeColorMap =
-            key === "type" &&
-            typeof keyData.value === "object" &&
-            keyData.value !== null &&
-            !Array.isArray(keyData.value);
-          const isArray = !isTypeColorMap && Array.isArray(keyData.value);
+        <div className="flex flex-col">
+          {Object.entries(data.nodeData).map(([key, keyData]) => {
+            const isTypeColorMap =
+              key === "type" &&
+              typeof keyData.value === "object" &&
+              keyData.value !== null &&
+              !Array.isArray(keyData.value);
+            const isArray = !isTypeColorMap && Array.isArray(keyData.value);
 
-          return (
-            <div
-              key={key}
-              className={`${data.isBooleanNode && "text-center"} flex`}
-              style={{
-                border: `1px solid ${data.nodeStyle.color}40`,
-                padding: "4px",
-                background: data.isBooleanNode
-                  ? `${data.nodeStyle.color}50`
-                  : "",
-              }}
-            >
-              <span className="font-semibold mr-2 whitespace-nowrap text-[var(--node-key-color)]">
-                {!data.isBooleanNode && `${key}:`}
-              </span>
+            return (
+              <div
+                key={key}
+                className={`${data.isBooleanNode && "text-center"} flex`}
+                style={{
+                  border: `1px solid ${data.nodeStyle.color}40`,
+                  padding: "4px",
+                  background: data.isBooleanNode
+                    ? `${data.nodeStyle.color}50`
+                    : "",
+                }}
+              >
+                <span className="font-semibold mr-2 whitespace-nowrap text-[var(--node-key-color)]">
+                  {!data.isBooleanNode && `${key}:`}
+                </span>
 
-              {isTypeColorMap ? (
-                <div className="flex-col w-full gap-1 flex py-1">
-                  {Object.entries(keyData.value as Record<string, string>).map(
-                    ([typeName, itemColor]) => (
+                {isTypeColorMap ? (
+                  <div className="flex-col w-full gap-1 flex py-1">
+                    {Object.entries(keyData.value as Record<string, string>).map(
+                      ([typeName, itemColor]) => (
+                        <div
+                          ref={(el) => {
+                            rowRefs.current[`${id}-${typeName}`] = el;
+                          }}
+                          key={typeName}
+                          className="px-2 py-[2px] rounded text-center font-medium shadow-sm"
+                          style={{
+                            border: `1px solid ${itemColor}`,
+                            backgroundColor: `${itemColor}33`,
+                            color:
+                              theme === "dark"
+                                ? itemColor
+                                : `color-mix(in srgb, ${itemColor} 60%, black)`,
+                          }}
+                        >
+                          {typeName}
+                        </div>
+                      )
+                    )}
+                  </div>
+                ) : isArray ? (
+                  <div className="flex-col w-full gap-1 flex py-1">
+                    {(keyData.value as string[]).map((item, index) => (
                       <div
                         ref={(el) => {
-                          rowRefs.current[`${id}-${typeName}`] = el;
+                          rowRefs.current[`${id}-${item}`] = el;
                         }}
-                        key={typeName}
-                        className="px-2 py-[2px] rounded text-center font-medium shadow-sm"
-                        style={{
-                          border: `1px solid ${itemColor}`,
-                          backgroundColor: `${itemColor}33`,
-                          color:
-                            theme === "dark"
-                              ? itemColor
-                              : `color-mix(in srgb, ${itemColor} 60%, black)`,
-                        }}
+                        key={index}
+                        className="px-2 py-[2px] bg-[var(--node-value-bg-color)]"
+                        style={{ border: `1px solid ${color}30` }}
                       >
-                        {typeName}
+                        {item}
                       </div>
-                    )
-                  )}
-                </div>
-              ) : isArray ? (
-                <div className="flex-col w-full gap-1 flex py-1">
-                  {(keyData.value as string[]).map((item, index) => (
-                    <div
-                      ref={(el) => {
-                        rowRefs.current[`${id}-${item}`] = el;
-                      }}
-                      key={index}
-                      className="px-2 py-[2px] bg-[var(--node-value-bg-color)]"
-                      style={{ border: `1px solid ${color}30` }}
-                    >
-                      {item}
-                    </div>
-                  ))}
-                </div>
-              ) : (
-                <span
-                  ref={(el) => {
-                    rowRefs.current[`${id}-${key}`] = el;
-                  }}
-                >
-                  {keyData.ellipsis ?? String(keyData.value)}
-                </span>
-              )}
-            </div>
-          );
-        })}
+                    ))}
+                  </div>
+                ) : (
+                  <span
+                    ref={(el) => {
+                      rowRefs.current[`${id}-${key}`] = el;
+                    }}
+                  >
+                    {keyData.ellipsis ?? String(keyData.value)}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
       </div>
 
       {data.sourceHandles.map(({ handleId, position }) => (


### PR DESCRIPTION
## Summary

This PR fixes a UI bug where the boolean node connection handles were being partially clipped. The issue occurred because overflow-hidden was applied to the outermost container of the node. To resolve this, the node's inner content is now wrapped in a dedicated inner div with overflow-hidden and rounded-[inherit]. This ensures the content is styled correctly without clipping the external connection handles.

## What kind of change does this PR introduce

 Bugfix (non-breaking change which fixes an issue)

## Issue Number

 #394

Closes  #394

## Screenshots/Video


<img width="1440" height="900" alt="Screenshot 2026-08-19 at 11 46 34 AM" src="https://github.com/user-attachments/assets/2be65506-e09f-4d48-ab74-f62e070bde3b" />


## Does this PR introduce a breaking change?

No

## If relevant, did you update the documentation?

NO
